### PR TITLE
Issue331 nosetests export import fails vagrant setup

### DIFF
--- a/nansat/tests/nansat_test_base.py
+++ b/nansat/tests/nansat_test_base.py
@@ -31,7 +31,7 @@ class NansatTestBase(unittest.TestCase):
         self.test_file_arctic = os.path.join(ntd.test_data_path, 'arctic.nc')
         self.tmp_data_path = ntd.tmp_data_path
         self.default_mapper = 'generic'
-        fd, self.tmp_filename = tempfile.mkstemp(suffix='.nc')#, dir=ntd.tmp_data_path)
+        fd, self.tmp_filename = tempfile.mkstemp(suffix='.nc')
         os.close(fd)
 
         if not os.path.exists(self.test_file_gcps):

--- a/nansat/tests/nansat_test_base.py
+++ b/nansat/tests/nansat_test_base.py
@@ -31,7 +31,7 @@ class NansatTestBase(unittest.TestCase):
         self.test_file_arctic = os.path.join(ntd.test_data_path, 'arctic.nc')
         self.tmp_data_path = ntd.tmp_data_path
         self.default_mapper = 'generic'
-        fd, self.tmp_filename = tempfile.mkstemp(suffix='.nc', dir=ntd.tmp_data_path)
+        fd, self.tmp_filename = tempfile.mkstemp(suffix='.nc')#, dir=ntd.tmp_data_path)
         os.close(fd)
 
         if not os.path.exists(self.test_file_gcps):


### PR DESCRIPTION
Removing the specified directory in the `tempfile.mkstemp` command (dir=ntd.tmp_data_path) in `nansat_test_base.py` will revert to the default (dir=None). A default temporary directory is then created to store the temporary files.
The temporary files are now detected by `gdal.GetDriverByName(driver).CreateCopy` in `exporter.py`, and `nosetests nansat` are finalised without an error.