### PR TITLE
Issue325 mock missing install nansat readme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ docs/_build/
 .pydevproject
 .idea
 .settings
+.vagrant

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ install:
   - conda info -a
 
   # Replace dep1 dep2 ... with your dependencies
-  - conda create -q -c conda-forge -n test-environment python=$TRAVIS_PYTHON_VERSION libnetcdf=4.4.1.1 gdal numpy pillow netcdf4 python-dateutil nose coveralls mock urllib3 basemap
+  - conda create -q -c conda-forge -n test-environment python=$TRAVIS_PYTHON_VERSION libnetcdf gdal numpy pillow netcdf4 python-dateutil nose coveralls mock urllib3 basemap
   - source activate test-environment
   - python setup.py install
 

--- a/README.rst
+++ b/README.rst
@@ -50,67 +50,28 @@ You will find information about contributing to Nansat at `Read the Docs`_.
 
 .. _Read the Docs: http://nansat.readthedocs.io/
 
-
 Installation
 ------------
 
-The easiest way to install Nansat on a Linux machine is to use
-`anaconda <http://docs.continuum.io/anaconda/index>`__
+The easiest way to install Nansat on any platform is to use Anaconda_ (`download installer <https://conda.io/miniconda.html>`_).
+
+.. _Anaconda: http://docs.continuum.io/anaconda/index
 
 ::
-
-    # download the latest version of miniconda
-    wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
-
-    # make it executable
-    chmod +x miniconda.sh
-
-    # install miniconda virtual environment
-    ./miniconda.sh -b -f -p $HOME/miniconda
-
-    # activate the miniconda environment
-    export PATH=$HOME/miniconda/bin/:$PATH
-
-    # update miniconda packages and metadata
-    conda update -q --yes conda
 
     # install Nansat and requirements from the conda-forge channel
     conda create -n py3nansat -c conda-forge nansat
-    
-    # activate the py3nansat environment
-    source activate py3nansat    
 
-Fore more information see
-`Install-Nansat <https://github.com/nansencenter/nansat/wiki/Install-Nansat>`__
-section or use pre-configure virtual machines as explained on
-`Nansat-lectures <https://github.com/nansencenter/nansat-lectures>`__
-
-
-Tests
------
-
-To modify code in any way, as a developer or just for your project, we encourage you to use the test functions. New functions should be accompanied with suitable tests, see Nansat conventions in `Read the Docs`_ .
-
-::
-
-    # install testing packages from conda-forge
-    conda install -c conda-forge nose mock
-
-    # run nansat.tests
-    nosetests nansat
-
-    # Run all tests including nansat_integration_tests with coverage
-    cd <nansat_repository_folder>
-    nosetests -w . --with-coverage --cover-package=nansat
-
-
-Usage
------
+Activate and work in the nansat environment
+-------------------------------------------
 
 ::
 
     # download a test file
     wget https://github.com/nansencenter/nansat/raw/develop/nansat/tests/data/stere.tif
+
+    # activate the py3nansat environment
+    source activate py3nansat
 
     # start python and work with Nansat
     python
@@ -132,10 +93,28 @@ Usage
     # create RGB with auto-stretched histogram
     n.write_figure('stere_rgb.png', [1,2,3], clim='hist')
 
-Fore more information see
-`Tutorial <https://github.com/nansencenter/nansat/wiki/Tutorial>`__ or
-notebooks for `Nansat
+
+Tests
+-----
+
+Nansat is outfitted with unittests, which you can use to ensure that all functionality works on your platform.
+
+::
+
+    # install testing packages from conda-forge
+    conda install -c conda-forge nose mock
+
+    # run nansat.tests
+    nosetests nansat
+
+    # Run all tests including nansat_integration_tests with coverage
+    cd <nansat_repository_folder>
+    nosetests -w . --with-coverage --cover-package=nansat    
+
+Fore more information see `Read the Docs`_ or notebooks for `Nansat
 lectures <https://github.com/nansencenter/nansat-lectures/tree/master/notebooks>`__
+
+.. _Read the Docs: http://nansat.readthedocs.io/
 
 License
 -------

--- a/README.rst
+++ b/README.rst
@@ -74,11 +74,27 @@ The easiest way to install Nansat on a Linux machine is to use
     # update miniconda packages and metadata
     conda update -q --yes conda
 
-    # install all requirements from conda-forge channel
-    conda install -q --yes -c conda-forge gdal numpy pillow netcdf4 python-dateutil pythesint nose
+    # install Nansat and requirements from the conda-forge channel
+    conda create -n py3nansat -c conda-forge nansat
+    
+    # activate the py3nansat environment
+    source activate py3nansat    
 
-    # finally install Nansat
-    pip install https://github.com/nansencenter/nansat/archive/master.tar.gz
+Fore more information see
+`Install-Nansat <https://github.com/nansencenter/nansat/wiki/Install-Nansat>`__
+section or use pre-configure virtual machines as explained on
+`Nansat-lectures <https://github.com/nansencenter/nansat-lectures>`__
+
+
+Tests
+-----
+
+To modify code in any way, as a developer or just for your project, we encourage you to use the test functions. New fuctions should be accompanied with suitable tests, see Nansat conventions in `Read the Docs`_ .
+
+::
+
+    # install testing packages from conda-forge
+    conda install -c conda-forge nose mock
 
     # run nansat.tests
     nosetests nansat
@@ -87,18 +103,19 @@ The easiest way to install Nansat on a Linux machine is to use
     cd <nansat_repository_folder>
     nosetests -w . --with-coverage --cover-package=nansat
 
-Fore more information see
-`Install-Nansat <https://github.com/nansencenter/nansat/wiki/Install-Nansat>`__
-section or use pre-configure virtual machines as explained on
-`Nansat-lectures <https://github.com/nansencenter/nansat-lectures>`__
 
 Usage
 -----
 
-.. code:: python
+::
 
     # download a test file
-    !wget https://github.com/nansencenter/nansat/raw/develop/nansat/tests/data/stere.tif
+    wget https://github.com/nansencenter/nansat/raw/develop/nansat/tests/data/stere.tif
+
+    # start python and work with Nansat
+    python
+
+.. code:: python
 
     # import main file opener
     from nansat import Nansat

--- a/README.rst
+++ b/README.rst
@@ -89,7 +89,7 @@ section or use pre-configure virtual machines as explained on
 Tests
 -----
 
-To modify code in any way, as a developer or just for your project, we encourage you to use the test functions. New fuctions should be accompanied with suitable tests, see Nansat conventions in `Read the Docs`_ .
+To modify code in any way, as a developer or just for your project, we encourage you to use the test functions. New functions should be accompanied with suitable tests, see Nansat conventions in `Read the Docs`_ .
 
 ::
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -6,18 +6,11 @@ Quickstart
 The fastest way to install nansat:
 
 * Install `Miniconda <https://conda.io/miniconda.html>`_ on your platform of choice.
- * When you install Miniconda on Windows, you will get a new app called "Anaconda Prompt".
-   Run this to access the conda installation.
- * On Linux/OS X use a regular terminal and make sure PATH is set to contain the installation
-   directory as explained by the installer.
 
 .. code-block:: bash
 
-   conda create -n nansat -y Python=3.6
-   source activate nansat
-   # On windows you would need to ommit source: *activate nansat*
-   conda install --yes -c conda-forge pythesint scipy=0.18.1 basemap gdal
-   pip install urllib3 pillow netcdf4 nansat
+	conda create -n nansat -c conda-forge
+	source activate nansat
 
 Nansat is now installed.
 For more details and other methods of installing Nansat, see below.
@@ -156,8 +149,26 @@ easily be done with *pip install nose mock*.
 Use a self-provisioned Virtual Machine
 --------------------------------------
 
-Another option is to use a virtual machine managed by Virtualbox and provisioned using Vagrant and
-Ansible. We provide `configurations for virtual machines
-<https://github.com/nansencenter/geo-spaas-vagrant>`_ for learning and development of Nansat.
-Following a clone of this repository and installation of virtualbox and vagrant, a vm used for
-courses can be installed by ``vagrant up course``.
+Another option to install Nansat in a controlled environment is to use a virtual machine. Configuration for `Vagrant <https://www.vagrantup.com/>`_ and `Ansible <https://www.ansible.com/>` that brings up and provision a `VirtualBox <https://www.virtualbox.org/>` machine is provided in Nansat repository. To start the machine you need to install Vagrant and VirtualBox on your computer; clone or download the nansat source code; and start the machine:
+
+download nansat source code
+
+::
+
+  git clone https://github.com/nansencenter/nansat.git
+  cd nansat
+
+start virtual machine
+
+::
+
+  vagrant up
+
+That's it! The virtual machine will be started and all software will be installed automatically. To start using Nansat you need to log in to the virtual machine and start Python from the conda environment:
+
+::
+
+  vagrant ssh
+  source activate py3nansat
+  python
+

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -9,7 +9,7 @@ The fastest way to install nansat:
 
 .. code-block:: bash
 
-	conda create -n nansat -c conda-forge
+	conda create -n nansat -c conda-forge nansat
 	source activate nansat
 
 Nansat is now installed.

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -144,24 +144,28 @@ is performed. Make sure to follow the `Nansat conventions <conventions.html>`_ i
 contribute to Nansat.
 
 In addition to the regular dependencies, developers also need to install nose and mock. This can
-easily be done with *pip install nose mock*.
+easily be done with
+
+::
+
+  pip install nose mock
 
 Use a self-provisioned Virtual Machine
 --------------------------------------
 
-Another option to install Nansat in a controlled environment is to use a virtual machine. Configuration for `Vagrant <https://www.vagrantup.com/>`_ and `Ansible <https://www.ansible.com/>` that brings up and provision a `VirtualBox <https://www.virtualbox.org/>` machine is provided in Nansat repository. To start the machine you need to install Vagrant and VirtualBox on your computer; clone or download the nansat source code; and start the machine:
-
-download nansat source code
+Another option to install Nansat in a controlled environment is to use a virtual machine. Configuration 
+for `Vagrant <https://www.vagrantup.com/>`_ and `Ansible <https://www.ansible.com/>`_ that brings up and 
+provision a `VirtualBox <https://www.virtualbox.org/>`_ machine is provided in Nansat repository. To start 
+the machine you need to install Vagrant and VirtualBox on your computer; clone or download the nansat 
+source code; and start the machine:
 
 ::
-
+  
+  # download nansat source code
   git clone https://github.com/nansencenter/nansat.git
   cd nansat
 
-start virtual machine
-
-::
-
+  #start virtual machine
   vagrant up
 
 That's it! The virtual machine will be started and all software will be installed automatically. To start using Nansat you need to log in to the virtual machine and start Python from the conda environment:


### PR DESCRIPTION
Updated `README.rst`:
**Installation** procedure with `conda-forge nansat` environment.
A new **Test** section that includes the installation of the `nose` and `mock` packages to be able to run nosetests nansat.
In **Usage** section, added a separate block before python command block.

The **Installation**,  **Usage**, and **Test** procedures are tested on a virtual machine with ubuntu/trusty64.