### PR TITLE
Issue240 travis coverall badges show develop

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,6 +6,7 @@
 | Develop | |Build Status Develop| | |AppVeyor Status Develop| | |Coverage Status Develop| |            |
 +---------+------------------------+---------------------------+---------------------------+------------+
 
+
 .. NOTE: include statements doesn't work with github README.rst - the first section here is repeated
 .. in docs/source/about.rst as well...
 
@@ -133,15 +134,15 @@ Acknowledgments
 Development is supported by the Research Council of Norway as a part of
 `NORMAP <https://normap.nersc.no/>`__ project (grant no. 195397/V30).
 
-.. |Build Status Master| image:: https://travis-ci.org/nansencenter/nansat.svg?branch=master
-   :target: https://travis-ci.org/nansencenter/nansat?branch=master
-.. |AppVeyor Status Master| image:: https://ci.appveyor.com/api/projects/status/la50x7l2yy4d9ljr/branch/master?svg=true
-   :target: https://ci.appveyor.com/project/akorosov/nansat/branch/master
-.. |Coverage Status Master| image:: https://coveralls.io/repos/nansencenter/nansat/badge.svg?branch=master&service=github
-   :target: https://coveralls.io/github/nansencenter/nansat?branch=master
+.. |Build Status Master| image:: https://travis-ci.org/nansencenter/nansat.svg?branch=issue341_scatterometer_mappers
+   :target: https://travis-ci.org/nansencenter/nansat/branches
+.. |AppVeyor Status Master| image:: https://ci.appveyor.com/api/projects/status/la50x7l2yy4d9ljr/branch/issue341_scatterometer_mappers
+   :target: https://ci.appveyor.com/project/akorosov/nansat/branch/issue341_scatterometer_mappers
+.. |Coverage Status Master| image:: https://coveralls.io/repos/nansencenter/nansat/badge.svg?branch=issue130
+   :target: https://coveralls.io/github/nansencenter/nansat?branch=issue130
 
 .. |Build Status Develop| image:: https://travis-ci.org/nansencenter/nansat.svg?branch=develop
-   :target: https://travis-ci.org/nansencenter/nansat?branch=develop
+   :target: https://travis-ci.org/nansencenter/nansat/branches
 .. |AppVeyor Status Develop| image:: https://ci.appveyor.com/api/projects/status/la50x7l2yy4d9ljr/branch/develop?svg=true
    :target: https://ci.appveyor.com/project/akorosov/nansat/branch/develop
 .. |Coverage Status Develop| image:: https://coveralls.io/repos/nansencenter/nansat/badge.svg?branch=develop&service=github

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,10 @@
-Branch  | Travis CI  | AppVeyor Status | Code Coverage | Zenodo DOI |
-------- | ---------- | --------------- | ------------- | ---------- |
-Master	| |Build Status Master| | |AppVeyor Status Master| | |Coverage Status Master| | |DOI| | 
-Develop | |Build Status Develop| | |AppVeyor Status Develop| | |Coverage Status Develop| | |
++---------+------------------------+---------------------------+---------------------------+------------+
+| Branch  | Travis CI              | AppVeyor Status           | Code Coverage             | Zenodo DOI |
++---------+------------------------+---------------------------+---------------------------+------------+
+| Master  | |Build Status Master|  | |AppVeyor Status Master|  | |Coverage Status Master|  | |DOI|      |
++---------+------------------------+---------------------------+---------------------------+------------+ 
+| Develop | |Build Status Develop| | |AppVeyor Status Develop| | |Coverage Status Develop| |            |
++---------+------------------------+---------------------------+---------------------------+------------+
 
 .. NOTE: include statements doesn't work with github README.rst - the first section here is repeated
 .. in docs/source/about.rst as well...
@@ -131,17 +134,18 @@ Development is supported by the Research Council of Norway as a part of
 `NORMAP <https://normap.nersc.no/>`__ project (grant no. 195397/V30).
 
 .. |Build Status Master| image:: https://travis-ci.org/nansencenter/nansat.svg?branch=master
-   :target: https://travis-ci.org/nansencenter/nansat
+   :target: https://travis-ci.org/nansencenter/nansat?branch=master
 .. |AppVeyor Status Master| image:: https://ci.appveyor.com/api/projects/status/la50x7l2yy4d9ljr/branch/master?svg=true
    :target: https://ci.appveyor.com/project/akorosov/nansat/branch/master
 .. |Coverage Status Master| image:: https://coveralls.io/repos/nansencenter/nansat/badge.svg?branch=master&service=github
-   :target: https://coveralls.io/r/nansencenter/nansat
+   :target: https://coveralls.io/github/nansencenter/nansat?branch=master
 
 .. |Build Status Develop| image:: https://travis-ci.org/nansencenter/nansat.svg?branch=develop
-   :target: https://travis-ci.org/nansencenter/nansat
+   :target: https://travis-ci.org/nansencenter/nansat?branch=develop
 .. |AppVeyor Status Develop| image:: https://ci.appveyor.com/api/projects/status/la50x7l2yy4d9ljr/branch/develop?svg=true
    :target: https://ci.appveyor.com/project/akorosov/nansat/branch/develop
 .. |Coverage Status Develop| image:: https://coveralls.io/repos/nansencenter/nansat/badge.svg?branch=develop&service=github
-   :target: https://coveralls.io/r/nansencenter/nansat
+   :target: https://coveralls.io/github/nansencenter/nansat?branch=develop
+
 .. |DOI| image:: https://zenodo.org/badge/DOI/10.5281/zenodo.59998.svg
    :target: https://doi.org/10.5281/zenodo.59998

--- a/README.rst
+++ b/README.rst
@@ -134,12 +134,12 @@ Acknowledgments
 Development is supported by the Research Council of Norway as a part of
 `NORMAP <https://normap.nersc.no/>`__ project (grant no. 195397/V30).
 
-.. |Build Status Master| image:: https://travis-ci.org/nansencenter/nansat.svg?branch=issue341_scatterometer_mappers
+.. |Build Status Master| image:: https://travis-ci.org/nansencenter/nansat.svg?branch=master
    :target: https://travis-ci.org/nansencenter/nansat/branches
-.. |AppVeyor Status Master| image:: https://ci.appveyor.com/api/projects/status/la50x7l2yy4d9ljr/branch/issue341_scatterometer_mappers
-   :target: https://ci.appveyor.com/project/akorosov/nansat/branch/issue341_scatterometer_mappers
-.. |Coverage Status Master| image:: https://coveralls.io/repos/nansencenter/nansat/badge.svg?branch=issue130
-   :target: https://coveralls.io/github/nansencenter/nansat?branch=issue130
+.. |AppVeyor Status Master| image:: https://ci.appveyor.com/api/projects/status/la50x7l2yy4d9ljr/branch/master?svg=true
+   :target: https://ci.appveyor.com/project/akorosov/nansat/branch/master
+.. |Coverage Status Master| image:: https://coveralls.io/repos/nansencenter/nansat/badge.svg?branch=master&service=github
+   :target: https://coveralls.io/github/nansencenter/nansat?branch=master
 
 .. |Build Status Develop| image:: https://travis-ci.org/nansencenter/nansat.svg?branch=develop
    :target: https://travis-ci.org/nansencenter/nansat/branches

--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,7 @@
-|Build Status| |AppVeyor Status| |Coverage Status| |DOI|
+Branch  | Travis CI  | AppVeyor Status | Code Coverage | Zenodo DOI |
+------- | ---------- | --------------- | ------------- | ---------- |
+Master	| |Build Status Master| | |AppVeyor Status Master| | |Coverage Status Master| | |DOI| | 
+Develop | |Build Status Develop| | |AppVeyor Status Develop| | |Coverage Status Develop| | |
 
 .. NOTE: include statements doesn't work with github README.rst - the first section here is repeated
 .. in docs/source/about.rst as well...
@@ -127,11 +130,18 @@ Acknowledgments
 Development is supported by the Research Council of Norway as a part of
 `NORMAP <https://normap.nersc.no/>`__ project (grant no. 195397/V30).
 
-.. |Build Status| image:: https://travis-ci.org/nansencenter/nansat.svg?branch=master
+.. |Build Status Master| image:: https://travis-ci.org/nansencenter/nansat.svg?branch=master
    :target: https://travis-ci.org/nansencenter/nansat
-.. |AppVeyor Status| image:: https://ci.appveyor.com/api/projects/status/la50x7l2yy4d9ljr/branch/master?svg=true
+.. |AppVeyor Status Master| image:: https://ci.appveyor.com/api/projects/status/la50x7l2yy4d9ljr/branch/master?svg=true
    :target: https://ci.appveyor.com/project/akorosov/nansat/branch/master
-.. |Coverage Status| image:: https://coveralls.io/repos/nansencenter/nansat/badge.svg?branch=master
+.. |Coverage Status Master| image:: https://coveralls.io/repos/nansencenter/nansat/badge.svg?branch=master&service=github
+   :target: https://coveralls.io/r/nansencenter/nansat
+
+.. |Build Status Develop| image:: https://travis-ci.org/nansencenter/nansat.svg?branch=develop
+   :target: https://travis-ci.org/nansencenter/nansat
+.. |AppVeyor Status Develop| image:: https://ci.appveyor.com/api/projects/status/la50x7l2yy4d9ljr/branch/develop?svg=true
+   :target: https://ci.appveyor.com/project/akorosov/nansat/branch/develop
+.. |Coverage Status Develop| image:: https://coveralls.io/repos/nansencenter/nansat/badge.svg?branch=develop&service=github
    :target: https://coveralls.io/r/nansencenter/nansat
 .. |DOI| image:: https://zenodo.org/badge/DOI/10.5281/zenodo.59998.svg
    :target: https://doi.org/10.5281/zenodo.59998


### PR DESCRIPTION
Due to restricted information about the current branch on GitHub, a table with latest checks of both master and develop branch, respectively, is included in README.rst file.
The links attached to the Travis CI badges are now linked to the overview of all branches on the Travis CI web page, otherwise always will refer to the latest (current) branch checked with Travis CI. 