### PR TITLE
Fixes issue 255

### DIFF
--- a/nansat/nansat.py
+++ b/nansat/nansat.py
@@ -28,6 +28,7 @@ import numpy as np
 from numpy import nanmedian
 from numpy.lib.recfunctions import append_fields
 from netCDF4 import Dataset
+from matplotlib import cm
 
 from nansat.domain import Domain
 from nansat.exporter import Exporter
@@ -933,10 +934,15 @@ class Nansat(Domain, Exporter):
         bMin = float(minmax.split(' ')[0])
         bMax = float(minmax.split(' ')[1])
         # Make colormap from WKV information
-        cmap = np.vstack([np.arange(256.),
-                          np.arange(256.),
-                          np.arange(256.),
-                          np.ones(256)*255]).T
+        try:
+            colormap = band.GetMetadataItem('colormap')
+            cmap = cm.get_cmap(colormap, 256)
+            cmap = cmap(np.arange(256)) * 255
+        except:
+            cmap = np.vstack([np.arange(256.),
+                              np.arange(256.),
+                              np.arange(256.),
+                              np.ones(256)*255]).T
         colorTable = gdal.ColorTable()
         for i in range(cmap.shape[0]):
             colorEntry = (int(cmap[i, 0]), int(cmap[i, 1]),

--- a/nansat/nansat.py
+++ b/nansat/nansat.py
@@ -28,7 +28,13 @@ import numpy as np
 from numpy import nanmedian
 from numpy.lib.recfunctions import append_fields
 from netCDF4 import Dataset
-from matplotlib import cm
+
+try:
+    from matplotlib import cm
+except ImportError:
+    MATPLOTLIB_IS_INSTALLED = False
+else:
+    MATPLOTLIB_IS_INSTALLED = True
 
 from nansat.domain import Domain
 from nansat.exporter import Exporter
@@ -939,6 +945,9 @@ class Nansat(Domain, Exporter):
             cmap = cm.get_cmap(colormap, 256)
             cmap = cmap(np.arange(256)) * 255
         except:
+            if not MATPLOTLIB_IS_INSTALLED:
+                self.logger.debug('Geotiff is only available in gray '
+                                  'since matplotlib is not installed.')
             cmap = np.vstack([np.arange(256.),
                               np.arange(256.),
                               np.arange(256.),


### PR DESCRIPTION
In master from revision 1.0.0 the method write_geotiffimage has been creating the files in gray scale even if  colormap has a different value the objects metadata.
This change first checks the metadata and only falls back to gray if it can't use the colormap given.
(As is stated in the docstring.)