### PR TITLE
get_pixelsize_meters method changed to get_pixel_size_meters

### DIFF
--- a/nansat/domain.py
+++ b/nansat/domain.py
@@ -691,7 +691,7 @@ class Domain(object):
         lon_grd, lat_grd = self.get_geolocation_grids()
         return lon_grd.min(), lon_grd.max(), lat_grd.min(), lat_grd.max(),
 
-    def get_pixelsize_meters(self):
+    def get_pixel_size_meters(self):
         """Returns the pixelsize (deltaX, deltaY) of the domain
 
         For projected domains, the exact result which is constant

--- a/nansat/nansat.py
+++ b/nansat/nansat.py
@@ -388,7 +388,7 @@ class Nansat(Domain, Exporter):
 
         # estimate factor if pixelsize is given
         if dst_pixel_size is not None:
-            src_pixel_size = np.array(self.get_pixelsize_meters(), np.float)[::-1]
+            src_pixel_size = np.array(self.get_pixel_size_meters(), np.float)[::-1]
             factor = (src_pixel_size / float(dst_pixel_size)).mean()
 
         factor = float(factor)

--- a/nansat/tests/test_domain.py
+++ b/nansat/tests/test_domain.py
@@ -427,7 +427,7 @@ class DomainTest(unittest.TestCase):
 
     def test_get_pixelsize_meters(self):
         d = Domain(4326, "-te 25 70 35 72 -ts 500 500")
-        x, y = d.get_pixelsize_meters()
+        x, y = d.get_pixel_size_meters()
         self.assertEqual(int(x), 444)
         self.assertEqual(int(y), 723)
         d = Domain(ds=gdal.Open(self.test_file_projected))


### PR DESCRIPTION
The "get_pixelsize_meters" method changed to "get_pixel_size_meters" to follow the conventions. 