### PR TITLE
#446 #444 fix coveralls report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ docs/_build/
 .vagrant
 provisioning/roles/andrewrothstein*
 provisioning/site.retry
+.vscode
+.devcontainer

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,18 @@ services:
   - docker
 
 install:
-  - docker build . -t nansat -f docker/Dockerfile_nansat
-  - pip install coveralls
+  - docker pull nansencenter/nansat_base:latest
 
+# The COVERALLS_REPO_TOKEN environment variable is defined in the Travis CI repository settings:
+# https://travis-ci.org/nansencenter/nansat/settings
 script:
-  - docker run --rm -v "$(pwd):/src" nansat coverage run --omit=nansat/mappers/*,nansat/tests/*,nansat/nansatmap.py --source=nansat setup.py test
-
-after_success:
-  - coveralls
+  - >
+    docker run --rm
+    -v "$(pwd):/src"
+    -e "COVERALLS_REPO_TOKEN=$COVERALLS_REPO_TOKEN"
+    -e "TRAVIS=true"
+    -e "TRAVIS_JOB_ID=$TRAVIS_JOB_ID"
+    -e "TRAVIS_BRANCH=$TRAVIS_BRANCH"
+    -e "TRAVIS_PULL_REQUEST=$TRAVIS_PULL_REQUEST"
+    nansencenter/nansat_base:latest
+    bash -c "coverage run --omit=nansat/mappers/*,nansat/tests/*,nansat/nansatmap.py --source=nansat setup.py test && coveralls"

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ install:
   - pip install coveralls
 
 script:
-  - docker run --rm -it -v "$(pwd):/src" nansat coverage run --omit=nansat/mappers/*,nansat/tests/*,nansat/nansatmap.py --source=nansat setup.py test
+  - docker run --rm -v "$(pwd):/src" nansat coverage run --omit=nansat/mappers/*,nansat/tests/*,nansat/nansatmap.py --source=nansat setup.py test
 
 after_success:
   - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ install:
   - pip install coveralls
 
 script:
-  - docker run --rm -it -v `pwd`:/src nansat coverage run --omit=nansat/mappers/*,nansat/tests/*,nansat/nansatmap.py --source=nansat setup.py test
+  - docker run --rm -it -v "$(pwd):/src" nansat coverage run --omit=nansat/mappers/*,nansat/tests/*,nansat/nansatmap.py --source=nansat setup.py test
 
 after_success:
   - coveralls

--- a/docker/Dockerfile_base
+++ b/docker/Dockerfile_base
@@ -28,6 +28,8 @@ RUN conda install setuptools \
     python-dateutil \
     scipy \
     urllib3 \
+    coverage \
+    coveralls \
 &&  conda remove qt pyqt --force \
 &&  conda clean -a -y \
 &&  rm /opt/conda/pkgs/* -rf \

--- a/docker/Dockerfile_nansat
+++ b/docker/Dockerfile_nansat
@@ -8,5 +8,3 @@ COPY nansat /tmp/nansat
 COPY setup.py /tmp/
 WORKDIR /tmp
 RUN python setup.py install
-
-RUN pip install coverage


### PR DESCRIPTION
Solves #444 and #446.
The `nansat_base` image is used for tests.
Coveralls is directly installed in the `nansat_base` image and run inside the container.

I used the recently created [nansencenter organization](https://hub.docker.com/repository/docker/nansencenter/nansat_base) on the Docker Hub.