### PR TITLE
Hotfix410 gdal3

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -66,7 +66,7 @@ An easy way to install Nansat requirements on any platform is to use Anaconda_ (
 ::
 
     # create environment with key requirements
-    conda create -y -n py3nansat gdal=2.4.2 numpy pillow netcdf4 scipy
+    conda create -y -n py3nansat gdal numpy pillow netcdf4 scipy
     # activate environment
     source activate py3nansat
     # install nansat

--- a/nansat/nansat.py
+++ b/nansat/nansat.py
@@ -1560,7 +1560,7 @@ class Nansat(Domain, Exporter):
         for pn in range(len(pix[1:])):
             px0, px1 = pix[pn], pix[pn+1]
             py0, py1 = lin[pn], lin[pn+1]
-            length = np.round(np.hypot(px1-px0, py0-py1))
+            length = int(np.round(np.hypot(px1-px0, py0-py1)))
             pixVector += list(np.linspace(px0, px1, length+1)[1:])
             linVector += list(np.linspace(py0, py1, length+1)[1:])
 

--- a/nansat/nsr.py
+++ b/nansat/nsr.py
@@ -62,7 +62,7 @@ class NSR(osr.SpatialReference, object):
         status = 1
         if srs is 0:
             # generate default WGS84 SRS
-            status = self.ImportFromWkt(osr.SRS_WKT_WGS84)
+            status = self.ImportFromEPSG(4326)
         elif isinstance(srs, str_types):
             # parse as proj4 string
             status = self.ImportFromProj4(str(srs))
@@ -71,7 +71,6 @@ class NSR(osr.SpatialReference, object):
                 status = self.ImportFromWkt(str(srs))
             if status > 0:
                 raise NansatProjectionError('Proj4 or WKT (%s) is wrong' % srs)
-        # TODO: catch long in python 3
         elif isinstance(srs, int):
             # parse as EPSG code
             status = self.ImportFromEPSG(srs)

--- a/nansat/tests/test_geolocation.py
+++ b/nansat/tests/test_geolocation.py
@@ -42,7 +42,7 @@ class GeolocationTest(unittest.TestCase):
         srs = osr.SpatialReference()
         status = srs.ImportFromWkt(ga.data['SRS'])
         self.assertEqual(status, 0)
-        self.assertEqual(srs.ExportToProj4(), '+proj=longlat +datum=WGS84 +no_defs')
+        self.assertEqual(srs.ExportToProj4().strip(), '+proj=longlat +datum=WGS84 +no_defs')
         self.assertEqual(ga.data['X_BAND'], '1')
         self.assertEqual(ga.data['Y_BAND'], '1')
         self.assertEqual(ga.x_vrt, x_vrt)

--- a/nansat/tests/test_geolocation.py
+++ b/nansat/tests/test_geolocation.py
@@ -15,6 +15,7 @@ import os
 
 import gdal
 import numpy as np
+import osr
 
 from nansat.vrt import VRT
 from nansat.geolocation import Geolocation
@@ -38,11 +39,10 @@ class GeolocationTest(unittest.TestCase):
         self.assertEqual(ga.data['LINE_STEP'], '1')
         self.assertEqual(ga.data['PIXEL_OFFSET'], '0')
         self.assertEqual(ga.data['PIXEL_STEP'], '1')
-        self.assertEqual(ga.data['SRS'], 'GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",'
-                                         '6378137,298.257223563,AUTHORITY["EPSG","7030"]],AUT'
-                                         'HORITY["EPSG","6326"]],PRIMEM["Greenwich",0,AUTHORI'
-                                         'TY["EPSG","8901"]],UNIT["degree",0.0174532925199433'
-                                         ',AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4326"]]')
+        srs = osr.SpatialReference()
+        status = srs.ImportFromWkt(ga.data['SRS'])
+        self.assertEqual(status, 0)
+        self.assertEqual(srs.ExportToProj4(), '+proj=longlat +datum=WGS84 +no_defs')
         self.assertEqual(ga.data['X_BAND'], '1')
         self.assertEqual(ga.data['Y_BAND'], '1')
         self.assertEqual(ga.x_vrt, x_vrt)

--- a/nansat/tests/test_nsr.py
+++ b/nansat/tests/test_nsr.py
@@ -58,14 +58,18 @@ class NSRTest(unittest.TestCase):
         self.assertTrue('longlat' in nsr.ExportToProj4())
 
     def test_init_from_wkt(self):
-        nsr = NSR(osr.SRS_WKT_WGS84)
+        nsr = NSR(
+        'GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,'\
+        'AUTHORITY["EPSG","7030"]],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0,'\
+        'AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],'\
+        'AXIS["Latitude",NORTH],AXIS["Longitude",EAST],AUTHORITY["EPSG","4326"]]')
 
         self.assertEqual(type(nsr), NSR)
         self.assertEqual(nsr.Validate(), 0)
         self.assertTrue('longlat' in nsr.ExportToProj4())
 
     def test_init_from_NSR(self):
-        nsr = NSR(NSR(osr.SRS_WKT_WGS84))
+        nsr = NSR(NSR(4326))
 
         self.assertEqual(type(nsr), NSR)
         self.assertEqual(nsr.Validate(), 0)

--- a/nansat/vrt.py
+++ b/nansat/vrt.py
@@ -1554,7 +1554,7 @@ class VRT(object):
             Source spatial reference system
         src_points : tuple of two or three N-D arrays
             Coordinates of points in the source spatial reference system. A tuple with (X, Y) or
-            (X, Y, Z) coordinates arrays. Each coordinate Each array can be a list, 1D, 2D, N-D
+            (X, Y, Z) coordinates arrays. Each array can be a list, 1D, 2D, N-D
             array.
         dst_srs : nansat.NSR
             Destination spatial reference
@@ -1562,16 +1562,23 @@ class VRT(object):
         Returns
         -------
         dst_points : tuple of two or three N-D arrays
-            Coordinates of points in the destination spatial reference system. A tuple with (X, Y) or
-            (X, Y, Z) coordinates arrays. Each coordinate Each array can be 1D, 2D, N-D
-            array. Shape of output arrays corrrrespond to shape of inputs.
+            Coordinates of points in the destination spatial reference system. A tuple with (X, Y)
+            or (X, Y, Z) coordinates arrays. Each array can be 1D, 2D, N-D.
+            Shape of output arrays corrrrespond to shape of inputs.
 
         """
         transformer = osr.CoordinateTransformation(src_srs, dst_srs)
         src_shape = np.array(src_points[0]).shape
+        if int(gdal.VersionInfo()[0]) >= 3 and src_srs.EPSGTreatsAsLatLong() == 1:
+            # swap input X/Y to lat/lon
+            src_points = list(src_points)
+            src_points[0], src_points[1] = src_points[1], src_points[0]
         src_points = list(zip(*[np.array(xyz).flatten() for xyz in src_points]))
         dst_points = transformer.TransformPoints(src_points)
         dst_x, dst_y, dst_z = np.array(list(zip(*dst_points)))
+        if int(gdal.VersionInfo()[0]) >= 3 and dst_srs.EPSGTreatsAsLatLong() == 1:
+            # swap output lat/lon to X/Y
+            dst_x, dst_y = dst_y, dst_x
         return dst_x.reshape(src_shape), dst_y.reshape(src_shape), dst_z.reshape(src_shape)
 
     def set_offset_size(self, axis, offset, size):

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ REQS                = [
                         "pythesint",
                         "urllib3",
                         "numpy",
-                        "gdal<3.0",
+                        "gdal",
                         "python-dateutil",
                     ]
 


### PR DESCRIPTION
Closes #410 

Adds compatibility with gdal 3:
* osr.SRS_WKT_WGS84 is not used anymore
* axis are swaped from x/y to lat/lon or from lat/lon to x/y if gdal version is 3 and spatial refercne has lat/lon axes order.
* few updates of tests