### PR TITLE
Build slim image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ services:
 # - DOCKER_ORG: the docker hub organization (or user) to which the image will be pushed
 # - DOCKER_USER: the docker hub user used to log in to the docker hub
 # - DOCKER_PASS: the password of this user
-# - PYPI_TOKEN   the token associated to pypi account for deployment. More information can be found here: https://pypi.org/help/#apitoken
+# - PYPI_TOKEN: the token associated to the pypi account for deployment. More information can be found here: https://pypi.org/help/#apitoken
 
 jobs:
   include:
@@ -15,9 +15,9 @@ jobs:
     - stage: 'Unit tests'
       if: type = push
       env:
-        - TESTING_IMAGE_NAME="nansencenter/nansat_base"
+        - BASE_IMAGE="${DOCKER_ORG}/nansat_base:latest-slim"
       install:
-        - docker pull "${TESTING_IMAGE_NAME}"
+        - docker pull "${BASE_IMAGE}"
       # The COVERALLS_REPO_TOKEN environment variable is defined in the Travis CI repository settings:
       # https://travis-ci.org/nansencenter/nansat/settings
       script:
@@ -29,13 +29,16 @@ jobs:
           -e "TRAVIS_JOB_ID=$TRAVIS_JOB_ID"
           -e "TRAVIS_BRANCH=$TRAVIS_BRANCH"
           -e "TRAVIS_PULL_REQUEST=$TRAVIS_PULL_REQUEST"
-          "${TESTING_IMAGE_NAME}"
-          bash -c "source /opt/conda/bin/activate && coverage run --omit=nansat/mappers/*,nansat/tests/*,nansat/nansatmap.py --source=nansat setup.py test && coveralls"
+          "${BASE_IMAGE}"
+          bash -c "apt update && apt install -y g++ &&
+          coverage run --omit=nansat/mappers/*,nansat/tests/*,nansat/nansatmap.py --source=nansat setup.py test && coveralls"
 
-    - stage: 'Build docker image'
+    - stage: 'Build docker images'
+      name: 'Build standard image'
       if: type = pull_request OR tag IS present
       env:
         - IMAGE_NAME="${DOCKER_ORG}/nansat"
+        - BASE_IMAGE="${DOCKER_ORG}/nansat_base:latest"
         - DOCKER_TMP_TAG='tmp'
       install:
         - docker pull "${IMAGE_NAME}" || true
@@ -43,6 +46,8 @@ jobs:
         - >
           docker build .
           --cache-from "${IMAGE_NAME}"
+          --build-arg "BASE_IMAGE=${BASE_IMAGE}"
+          --build-arg "NANSAT_VERSION=${TRAVIS_TAG}"
           -t "${IMAGE_NAME}:${DOCKER_TMP_TAG}"
         - docker run --rm "${IMAGE_NAME}:${DOCKER_TMP_TAG}" python -c 'import nansat'
       before_deploy:
@@ -52,6 +57,30 @@ jobs:
           on:
             tags: true
           script: /bin/bash scripts/docker_push.sh "${TRAVIS_TAG}" latest
+
+    - name: 'Build slim image'
+      if: type = pull_request OR tag IS present
+      env:
+        - IMAGE_NAME="${DOCKER_ORG}/nansat"
+        - BASE_IMAGE="${DOCKER_ORG}/nansat_base:latest-slim"
+        - DOCKER_TAG_SUFFIX='-slim'
+        - DOCKER_TMP_TAG='tmp'
+      install:
+        - docker pull "${IMAGE_NAME}:latest${DOCKER_TAG_SUFFIX}" || true
+      script:
+        - >
+          docker build .
+          --cache-from "${IMAGE_NAME}:latest${DOCKER_TAG_SUFFIX}"
+          --build-arg "BASE_IMAGE=${BASE_IMAGE}"
+          -t "${IMAGE_NAME}:${DOCKER_TMP_TAG}"
+        - docker run --rm "${IMAGE_NAME}:${DOCKER_TMP_TAG}" python -c 'import nansat'
+      before_deploy:
+        - docker login -u "${DOCKER_USER}" -p "${DOCKER_PASS}"
+      deploy:
+        - provider: script
+          on:
+            tags: true
+          script: /bin/bash scripts/docker_push.sh "${TRAVIS_TAG}${DOCKER_TAG_SUFFIX}" "latest${DOCKER_TAG_SUFFIX}"
 
     - stage: 'PyPI deployment'
       if: tag IS present

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,18 @@
-FROM nansencenter/nansat_base
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE}
 
 COPY utilities /tmp/utilities
 COPY nansat /tmp/nansat
 COPY setup.py /tmp/
 WORKDIR /tmp
-RUN python setup.py install \
-    &&  rm -rf /tmp/{utilities,nansat,setup.py}
+RUN apt update \
+&&  apt install -y --no-install-recommends g++ \
+&&  python setup.py install \
+&&  rm -rf /tmp/{utilities,nansat,setup.py} \
+&&  apt remove -y gcc \
+&&  apt autoremove -y \
+&&  apt clean \
+&&  rm -rf /var/lib/apt/lists/*
+
 
 WORKDIR /src


### PR DESCRIPTION
I added the build of a slim Docker image based on **nansencenter/nansat_base:latest-slim**.

Unfortunately I could not build and use a wheel as I intended, because PyPI only accepts "manylinux" wheels (see https://github.com/pypa/manylinux).
I think this would require too much effort for the gain, so I stuck with the previous approach.

The built image is available for tests as **aperrin66/nansat:latest-slim**.
@akorosov if you can spare the time to test it in a real use case, that would be great!