### PR TITLE
Do not remove gcc from the standard image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
+# Necessary to access the BASE_IMAGE variable during the build
+ARG BASE_IMAGE
 
 COPY utilities /tmp/utilities
 COPY nansat /tmp/nansat
@@ -9,10 +11,9 @@ RUN apt update \
 &&  apt install -y --no-install-recommends g++ \
 &&  python setup.py install \
 &&  rm -rf /tmp/{utilities,nansat,setup.py} \
-&&  apt remove -y gcc \
+&&  if [ -n "`echo $BASE_IMAGE | grep slim`" ];then apt remove -y gcc;fi \
 &&  apt autoremove -y \
 &&  apt clean \
 &&  rm -rf /var/lib/apt/lists/*
-
 
 WORKDIR /src


### PR DESCRIPTION
Closes #488 

Necessary to build the standard geospaas image.