### PR TITLE
Support for new Cartopy version

### DIFF
--- a/nansat/exporter.py
+++ b/nansat/exporter.py
@@ -429,10 +429,10 @@ class Exporter(object):
                     'institution': Exporter.DEFAULT_INSTITUTE,
                     'source': Exporter.DEFAULT_SOURCE,
                     'creation_date': created,
-                    'northernmost_latitude': np.float(max_lat),
-                    'southernmost_latitude': np.float(min_lat),
-                    'westernmost_longitude': np.float(min_lon),
-                    'easternmost_longitude': np.float(max_lon),
+                    'northernmost_latitude': float(max_lat),
+                    'southernmost_latitude': float(min_lat),
+                    'westernmost_longitude': float(min_lon),
+                    'easternmost_longitude': float(max_lon),
                     'history': ' '}
         global_metadata.update(metadata)
 

--- a/nansat/mappers/mapper_netcdf_cf.py
+++ b/nansat/mappers/mapper_netcdf_cf.py
@@ -142,7 +142,7 @@ class Mapper(VRT):
     def _time_count_to_np_datetime64(self, time_count, time_reference=None):
         if not time_reference:
             time_reference = self._time_reference()
-        time_count = np.float(time_count)
+        time_count = float(time_count)
         time_decimal = time_count - np.floor(time_count)
         if 'second' in time_reference[1]:
             tt = np.datetime64(time_reference[0] +

--- a/nansat/nansat.py
+++ b/nansat/nansat.py
@@ -378,7 +378,7 @@ class Nansat(Domain, Exporter):
 
     def _get_resize_shape(self, factor, width, height, dst_pixel_size):
         """Estimate new shape either from factor or destination width/height or pixel size"""
-        src_shape = np.array(self.shape(), np.float)
+        src_shape = np.array(self.shape(), float)
         # estimate factor if either width or height is given and factor is not given
         if width is not None:
             factor = width / src_shape[1]
@@ -387,7 +387,7 @@ class Nansat(Domain, Exporter):
 
         # estimate factor if pixelsize is given
         if dst_pixel_size is not None:
-            src_pixel_size = np.array(self.get_pixelsize_meters(), np.float)[::-1]
+            src_pixel_size = np.array(self.get_pixelsize_meters(), float)[::-1]
             factor = (src_pixel_size / float(dst_pixel_size)).mean()
 
         factor = float(factor)

--- a/nansat/tests/test_tools.py
+++ b/nansat/tests/test_tools.py
@@ -95,4 +95,6 @@ class ToolsTest(unittest.TestCase):
         self.assertTrue(os.path.exists(tmpfilename))
         i = Image.open(tmpfilename)
         i.verify()
-        self.assertEqual(i.info['dpi'], (100, 100))
+        # with cartopy>=0.20.0, the dpi attribute is not
+        # always (100, 100)
+        self.assertEqual(tuple(np.round(i.info['dpi'], 1)), (100, 100))


### PR DESCRIPTION
Resolves #512 

Needs to be merged before nansencenter/docker-nansat-base#19.

Upgrading to Cartopy 0.20.1 involves also upgrading other libraries, including:
- scipy to 1.7
- gdal to 3.4
- matplotlib to 3.5
- numpy to 1.21

This creates some problems when running the unit tests, as explained in #512.
- The problem in **TestExporter__export2thredds.test_example1** has been solved by catching the RunTimeError and re-trying to instantiate a transformer with the suggested option.
- The problem with **ToolsTest.test_save_domain_map** has been solved by rounding the dpi tuple => @akorosov is this good enough?
- The problem with **NansatTest.test_resize_complex_alg_average** has been solved by replacing the use of `np.float` by `float`, as recommended in [Numpy's documentation](https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations).

There might be other problems which are not revealed by the unit tests and of which I am not aware.
I tried to run the integration tests using the data at ftp://ftp.nersc.no/nansat/test_data, but it does not seem to be the right data to run these tests. @akorosov do you know if the test data is available somewhere at NERSC?

FYI @korvinos 