### PR TITLE
update base image version to 2.1.0

### DIFF
--- a/.github/workflows/tests_build.yml
+++ b/.github/workflows/tests_build.yml
@@ -8,8 +8,8 @@ on:
 env:
   IMAGE_NAME: "${{ secrets.DOCKER_ORG }}/nansat"
   BASE_IMAGE_NAME: "${{ secrets.DOCKER_ORG }}/nansat_base"
-  BASE_STANDARD_IMAGE_TAG: '2.0.3'
-  BASE_SLIM_IMAGE_TAG: '2.0.3-slim'
+  BASE_STANDARD_IMAGE_TAG: '2.1.0'
+  BASE_SLIM_IMAGE_TAG: '2.1.0-slim'
 jobs:
   tests:
     name: 'Run unit tests'


### PR DESCRIPTION
Brings cartopy version upgrade (nansencenter/docker-nansat-base#19).

FYI @akorosov 