### PR TITLE
Update vrt.py to fix python optimization

### DIFF
--- a/nansat/vrt.py
+++ b/nansat/vrt.py
@@ -1729,6 +1729,8 @@ class VRT(object):
 
         # find DataType of source (if not given in src)
         if src['SourceBand'] > 0 and 'DataType' not in src:
+            # prevent Python from releasing the dataset's handle
+            # prematurely
             ds = gdal.Open(src['SourceFilename'])
             raster_band = ds.GetRasterBand(src['SourceBand'])
             src['DataType'] = raster_band.DataType

--- a/nansat/vrt.py
+++ b/nansat/vrt.py
@@ -1729,7 +1729,8 @@ class VRT(object):
 
         # find DataType of source (if not given in src)
         if src['SourceBand'] > 0 and 'DataType' not in src:
-            raster_band = gdal.Open(src['SourceFilename']).GetRasterBand(src['SourceBand'])
+            ds = gdal.Open(src['SourceFilename'])
+            raster_band = ds.GetRasterBand(src['SourceBand'])
             src['DataType'] = raster_band.DataType
 
         if 'xSize' not in src or 'ySize' not in src:


### PR DESCRIPTION
In the line
raster_band = gdal.Open(src['SourceFilename']).GetRasterBand(src['SourceBand'])

python optimizes it and releases  the open dataset before a next line uses the raster_band. As a result, the raster_band handle has been already invalid at that time and can not be used (an error raised).

A salution that prevents the release of the open dataset is a variable containing its handle. It is defined as:
ds = gdal.Open(src['SourceFilename'])