### PR TITLE
Use pip instead of setup.py to install nansat in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ COPY setup.py /tmp/
 WORKDIR /tmp
 RUN apt update \
 &&  apt install -y --no-install-recommends g++ \
-&&  python setup.py install \
+&&  pip install . \
 &&  rm -rf /tmp/{utilities,nansat,setup.py} \
 &&  apt autoremove -y \
 &&  apt clean \


### PR DESCRIPTION
Using setup.py installs the package as an egg, which is deprecated.