### PR TITLE
Fix nansat version used in pypi build

### DIFF
--- a/.github/workflows/tests_build.yml
+++ b/.github/workflows/tests_build.yml
@@ -113,7 +113,7 @@ jobs:
           python-version: 3.11
 
       - name: Build package
-        run: NANSAT_RELEASE="${TAG}" python setup.py sdist
+        run: NANSAT_RELEASE="${{ github.ref_type == 'tag' && github.ref_name || '0.0.0' }}" python setup.py sdist
         shell: bash
 
       - name: Publish


### PR DESCRIPTION
This went through the cracks during the upgrade to support multiple Python versions