### PR TITLE
Hotfix: release metadata

### DIFF
--- a/.github/workflows/tests_build.yml
+++ b/.github/workflows/tests_build.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
       - name: 'Checkout repository'
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -106,6 +108,8 @@ jobs:
     steps:
       - name: 'Checkout repository'
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Build package
         run: docker run --rm -v "$(pwd):/src" "$BASE_IMAGE_NAME" python setup.py sdist

--- a/.github/workflows/tests_build.yml
+++ b/.github/workflows/tests_build.yml
@@ -82,7 +82,6 @@ jobs:
           context: .
           build-args: |
             BASE_IMAGE=${{ env.BASE_IMAGE_NAME }}:${{ env.BASE_IMAGE_TAG }}-python${{ matrix.python_version }}
-            NANSAT_RELEASE=${{ github.ref_type == 'tag' && github.ref_name || '0.0.0' }}
           push: ${{ github.ref_type == 'tag' }}
           tags: |
             ${{ env.IMAGE_NAME }}:${{ github.ref_name }}-python${{ matrix.python_version }}

--- a/.github/workflows/tests_build.yml
+++ b/.github/workflows/tests_build.yml
@@ -107,13 +107,8 @@ jobs:
       - name: 'Checkout repository'
         uses: actions/checkout@v4
 
-      - name: Set up Python 3.11
-        uses: actions/setup-python@v4
-        with:
-          python-version: 3.11
-
       - name: Build package
-        run: NANSAT_RELEASE="${{ github.ref_type == 'tag' && github.ref_name || '0.0.0' }}" python setup.py sdist
+        run: docker run --rm -v "$(pwd):/src" "$BASE_IMAGE_NAME" python setup.py sdist
         shell: bash
 
       - name: Publish

--- a/.github/workflows/tests_build.yml
+++ b/.github/workflows/tests_build.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: ['**']
   release:
-    types: [released]
+    types: [prereleased, released]
 env:
   IMAGE_NAME: "${{ vars.DOCKER_ORG }}/nansat"
   BASE_IMAGE_NAME: "${{ vars.DOCKER_ORG }}/nansat_base"

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,14 +5,12 @@ ARG BASE_IMAGE
 
 ARG NANSAT_RELEASE
 
-COPY utilities /tmp/utilities
-COPY nansat /tmp/nansat
-COPY setup.py /tmp/
-WORKDIR /tmp
+COPY . /tmp/nansat/
+WORKDIR /tmp/nansat
 RUN apt update \
 &&  apt install -y --no-install-recommends g++ \
 &&  pip install . \
-&&  rm -rf /tmp/{utilities,nansat,setup.py} \
+&&  rm -rf /tmp/nansat \
 &&  apt autoremove -y \
 &&  apt clean \
 &&  rm -rf /var/lib/apt/lists/*

--- a/setup.py
+++ b/setup.py
@@ -213,7 +213,6 @@ def run_setup(skip_compile):
 
     setup(
         name=NAME,
-        version=VERSION,
         maintainer=MAINTAINER,
         maintainer_email=MAINTAINER_EMAIL,
         description=DESCRIPTION,
@@ -237,6 +236,8 @@ def run_setup(skip_compile):
         cmdclass = {'install_scripts': my_install_scripts},
         install_requires=REQS,
         test_suite="nansat.tests",
+        use_scm_version=True,
+        setup_requires=['setuptools_scm'],
         **kw
     )
 


### PR DESCRIPTION
Use `setuptools_scm` to get the version number from git when releasing.
This will fix the current issues with the NANSAT_RELEASE environment variable when installing the source package.